### PR TITLE
chore: financial dashboard view updates

### DIFF
--- a/src/screens/FinancialPerformance/BalanceSheet/index.js
+++ b/src/screens/FinancialPerformance/BalanceSheet/index.js
@@ -33,7 +33,7 @@ const BalanceSheet = ({
         mt={20}
       >
         <TabList my={8}>
-          <Tab
+          {/* <Tab
             color={darkMode.value ? "gray.100" : "gray.700"}
             borderRadius={15}
             _selected={{
@@ -43,10 +43,8 @@ const BalanceSheet = ({
               borderRadius: 15,
             }}
           >
-
             Balance Sheet
-
-          </Tab>
+          </Tab> */}
           <Tab
             color={darkMode.value ? "gray.100" : "gray.700"}
             borderRadius={15}
@@ -61,7 +59,7 @@ const BalanceSheet = ({
           </Tab>
         </TabList>
         <TabPanels>
-          <TabPanel>
+          {/* <TabPanel>
             <Box
               bg="bg-surface"
               boxShadow={{
@@ -83,7 +81,7 @@ const BalanceSheet = ({
             <Stack spacing="5">
               <BalanceGraph balanceSheet={balanceSheet} />
             </Stack>
-          </TabPanel>
+          </TabPanel> */}
           <TabPanel>
             <Box
               bg="bg-surface"

--- a/src/screens/FinancialPerformance/FinancialPerformance.js
+++ b/src/screens/FinancialPerformance/FinancialPerformance.js
@@ -58,6 +58,17 @@ const OpsPerformance = () => {
               _focus: { boxShadow: "none", outline: "none" },
             }}
           >
+            Profit & Loss
+          </Tab>
+          <Tab
+            color={"white"}
+            _selected={{
+              color: "gray.700",
+              bg: "#68D391",
+              borderRadius: 5,
+              _focus: { boxShadow: "none", outline: "none" },
+            }}
+          >
             Balance Sheet
           </Tab>
           <Tab
@@ -71,20 +82,17 @@ const OpsPerformance = () => {
           >
             Revenue Streams
           </Tab>
-          <Tab
-            color={"white"}
-            _selected={{
-              color: "gray.700",
-              bg: "#68D391",
-              borderRadius: 5,
-              _focus: { boxShadow: "none", outline: "none" },
-            }}
-          >
-            Profit & Loss
-          </Tab>
+          
         </TabList>
 
         <TabPanels>
+          <TabPanel>
+            <ProfitAndLoss
+              quarterly={quarterly}
+              quartly={quartly}
+              monthly={monthly}
+            />
+          </TabPanel>
           <TabPanel>
             <div>
               <BalanceSheet
@@ -99,13 +107,6 @@ const OpsPerformance = () => {
               revenueStreams={revenueStreams}
               revenueStreamsQuarterly={revenueStreamsQuarterly}
               revenueStreamsPivotQuarterly={revenueStreamsPivotQuarterly}
-            />
-          </TabPanel>
-          <TabPanel>
-            <ProfitAndLoss
-              quarterly={quarterly}
-              quartly={quartly}
-              monthly={monthly}
             />
           </TabPanel>
         </TabPanels>

--- a/src/screens/FinancialPerformance/ProfitAndLoss/index.js
+++ b/src/screens/FinancialPerformance/ProfitAndLoss/index.js
@@ -34,7 +34,7 @@ const ProfitAndLoss = ({
         mt={20}
       >
         <TabList my={8}>
-          <Tab
+          {/* <Tab
             color={darkMode.value ? "gray.100" : "gray.700"}
             borderRadius={15}
             _selected={{
@@ -45,7 +45,7 @@ const ProfitAndLoss = ({
             }}
           >
             Profit & Loss
-          </Tab>
+          </Tab> */}
           <Tab
             color={darkMode.value ? "gray.100" : "gray.700"}
             _selected={{
@@ -60,7 +60,7 @@ const ProfitAndLoss = ({
           </Tab>
         </TabList>
         <TabPanels>
-          <TabPanel>
+          {/* <TabPanel>
             <Box
               bg="bg-surface"
               boxShadow={{
@@ -84,7 +84,7 @@ const ProfitAndLoss = ({
               monthly={monthly}
               title="Timeseries Profit / Loss"
             />
-          </TabPanel>
+          </TabPanel> */}
           <TabPanel>
             <Box
               bg="bg-surface"

--- a/src/screens/FinancialPerformance/RevenueStreams/index.js
+++ b/src/screens/FinancialPerformance/RevenueStreams/index.js
@@ -31,7 +31,7 @@ const RevenueStreams = ({
         mt={20}
       >
         <TabList my={8}>
-          <Tab
+          {/* <Tab
             color={darkMode.value ? "gray.100" : "gray.700"}
             borderRadius={15}
             _selected={{
@@ -42,7 +42,7 @@ const RevenueStreams = ({
             }}
           >
             Revenue Streams
-          </Tab>
+          </Tab> */}
           <Tab
             color={darkMode.value ? "gray.100" : "gray.700"}
             borderRadius={15}
@@ -53,11 +53,11 @@ const RevenueStreams = ({
               _focus: { boxShadow: "none", outline: "none" },
             }}
           >
-            Quarterly Revenue
+            Quarterly
           </Tab>
         </TabList>
         <TabPanels>
-          <TabPanel>
+          {/* <TabPanel>
             <Box
               bg="bg-surface"
               boxShadow={{
@@ -79,7 +79,7 @@ const RevenueStreams = ({
             <Stack spacing="5">
               <RevenueGraph revenueStreams={revenueStreams} />
             </Stack>
-          </TabPanel>
+          </TabPanel> */}
           <TabPanel>
             <Box
               bg="bg-surface"


### PR DESCRIPTION
![CleanShot 2022-06-19 at 23 11 35](https://user-images.githubusercontent.com/104367442/174518671-39ad5e2f-6db8-463a-ba0c-e95b83885405.png)

Changes made:

- Reorder the Financials top nav to be in this order:
  - Profit and Loss
  - Balance Sheet
  - Revenue Streams
- for all three views, only keep the "Quarterly" view - you can make that the default, and we can hide the aggregated view, and we can hide that secondary navbar item